### PR TITLE
Persist session

### DIFF
--- a/src/actions/session.js
+++ b/src/actions/session.js
@@ -6,6 +6,13 @@ function setCurrentUser(dispatch, resp) {
   dispatch({ type: 'AUTH_SUCCESS', resp });
 }
 
+export function authenticate(data) {
+  return dispatch => api.post('/session/refresh', data)
+    .then((resp) => {
+      setCurrentUser(dispatch, resp);
+    });
+}
+
 export function signin(data, router) {
   return dispatch => api.post('/session', data)
     .then((resp) => {

--- a/src/actions/session.js
+++ b/src/actions/session.js
@@ -7,7 +7,6 @@ function setCurrentUser(dispatch, resp) {
 }
 
 export function signin(data, router) {
-  console.log('signing in . . .');
   return dispatch => api.post('/session', data)
     .then((resp) => {
       setCurrentUser(dispatch, resp);

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 //  import PropTypes from 'prop-types';
 import { connect } from 'react-redux'; //  to connect to store
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
-import { authenticate } from '.../actions/session'; //  authenticate on mount
+import { authenticate } from '../actions/session'; //  authenticate on mount
 import Home from './Home';
 import Register from './Register';
 import Signin from './Signin';

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,10 +1,31 @@
+//  @flow
+
 import React, { Component } from 'react';
+//  import PropTypes from 'prop-types';
+import { connect } from 'react-redux'; //  to connect to store
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { authenticate } from '.../actions/session'; //  authenticate on mount
 import Home from './Home';
 import Register from './Register';
 import Signin from './Signin';
 
+
+type Props = {
+  authenticate: () => void,
+}
+
 class App extends Component {
+  componentDidMount() {
+    //  upon mount (refresh), if a token is present, authenticate
+    // to persist user session
+    const token = localStorage.getItem('token');
+    if (token) {
+      this.props.authenticate();
+    }
+  }
+
+  props: Props
+
   render() {
     return (
       <BrowserRouter>
@@ -18,4 +39,7 @@ class App extends Component {
   }
 }
 
-export default App;
+export default connect(
+  null, //  the state?
+  { authenticate }, //  the action to perform
+)(App);


### PR DESCRIPTION
Persist a user's session by POSTing to the Coinwatch API at `/session/refresh` when the `App` component mounts